### PR TITLE
Allow profile_response to accept Object hash for ordered_list

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1994,7 +1994,7 @@ Type: [Object][365]
 ### Properties
 
 *   `profile_requirement_uid` **[string][326]** A UID referring to the Profile Requirement
-*   `profile_response` **[string][326]** The Customer's response to the Profile Requirement/\*\*
+*   `profile_response` **([string][326] | [object][365])** The Customer's response to the Profile Requirement, pending on the question may require a string or object ordered hash list response./\*\*
 *   `status` **(`"initiated"` | `"queued"` | `"identity_verified"` | `"active"` | `"manual_review"` | `"rejected"` | `"archived"` | `"under_review"`)?** Filter by onboarding status. Please note that the initiated enum value will not be respected unless the `include_initiated=true` parameter is also provided.
 *   `include_initiated` **[boolean][370]?** By default, Customers in initiated status are not shown, even if the `status=initiated` parameter is provided. In order for Customers with status initiated to appear in search results, parameters must include `include_initiated=true`.
 *   `kyc_status` **(`"approved"` | `"denied"` | `"documents_provided"` | `"documents_rejected"` | `"manual_review"` | `"pending_documents"` | `"ready_for_custodial_partner_review"` | `"under_review"`)?** Filter by KYC status.

--- a/lib/core/customer.js
+++ b/lib/core/customer.js
@@ -217,11 +217,11 @@ class CustomerService {
      */
     _validateProfileAnswerDetails(details) {
         const { profile_requirement_uid, profile_response } = details;
-        
+
         if (validator.isEmpty(profile_requirement_uid, { ignore_whitespace: true })) {
             throw new Error('"profile_requirement_uid" is required.');
         }
-        if (validator.isEmpty(profile_response, { ignore_whitespace: true })) {
+        if (!profile_response) {
             throw new Error('"profile_response" is required.');
         }
     }
@@ -402,7 +402,6 @@ class CustomerService {
         }
 
         const answers = Array.isArray(details) ? details : [details];
-
         answers.forEach(this._validateProfileAnswerDetails);
 
         const response = await this._api.put(

--- a/lib/core/typedefs/customer.typedefs.js
+++ b/lib/core/typedefs/customer.typedefs.js
@@ -47,7 +47,7 @@
 /**
  * @typedef {Object} CustomerProfileAnswerDetails
  * @property {string} profile_requirement_uid - A UID referring to the Profile Requirement
- * @property {string} profile_response - The Customer's response to the Profile Requirement
+ * @property {string | object} profile_response - The Customer's response to the Profile Requirement, pending on the question may require a string or object ordered hash list response.
 
 /**
   * @typedef {Object} CustomerListQuery

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,34 +1,34 @@
 {
   "name": "@rizefinance/rize-js",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rizefinance/rize-js",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "ISC",
       "dependencies": {
-        "axios": "^0.24.0",
-        "jsrsasign": "^10.5.1",
+        "axios": "^0.25.0",
+        "jsrsasign": "^10.5.3",
         "lodash": "^4.17.21",
-        "query-string": "^7.1.0",
+        "query-string": "^7.1.1",
         "stompit": "^1.0.0",
         "validator": "^13.7.0"
       },
       "devDependencies": {
+        "@faker-js/faker": "^6.0.0-alpha.6",
         "@types/jsrsasign": "^9.0.3",
         "@types/stompit": "^0.26.3",
         "@types/validator": "^13.7.1",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
-        "chai": "^4.3.4",
+        "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
         "documentation": "^13.2.5",
         "dotenv": "^16.0.0",
         "eslint": "^7.32.0",
         "eslint-plugin-chai-friendly": "^0.7.2",
-        "faker": "^6.6.6",
         "mocha": "^8.4.0",
         "mocha-logger": "^1.0.7",
         "ssn": "^1.0.3",
@@ -513,6 +513,16 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "6.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0-alpha.6.tgz",
+      "integrity": "sha512-+jatKq8wYwOgCpVQ0wE4t9BglS16qJH/Nu4WjPU+ABTywivTY8BCsD1XIZhw9iXDq3t1InyiXmz+R70TcUMbrg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1398,11 +1408,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/babelify": {
@@ -1694,15 +1704,16 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       },
@@ -3573,12 +3584,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/faker": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
-      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg==",
-      "dev": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5029,9 +5034,9 @@
       }
     },
     "node_modules/jsrsasign": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.1.tgz",
-      "integrity": "sha512-yW0fq87KNZFw4Pn5ySllXs3ztZAROQZczEheKZTqmiNpCe/Xj9r5NhuAQ7MXTOyEZGJ/+MPHGTsfbgPFaLpwHQ==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.3.tgz",
+      "integrity": "sha512-5QEQN05HzXxLNVsnd50y6e/vNyKCeFTDu8xwgYbtWOLJKZQf148vmi9DhPEfhLThz22vJm9iyDY39ekmXBSj2A==",
       "funding": {
         "url": "https://github.com/kjur/jsrsasign#donations"
       }
@@ -5237,6 +5242,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -6935,9 +6949,9 @@
       }
     },
     "node_modules/query-string": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.0.tgz",
-      "integrity": "sha512-wnJ8covk+S9isYR5JIXPt93kFUmI2fQ4R/8130fuq+qwLiGVTurg7Klodgfw4NSz/oe7xnyi09y3lSrogUeM3g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+      "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -9780,6 +9794,12 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@faker-js/faker": {
+      "version": "6.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0-alpha.6.tgz",
+      "integrity": "sha512-+jatKq8wYwOgCpVQ0wE4t9BglS16qJH/Nu4WjPU+ABTywivTY8BCsD1XIZhw9iXDq3t1InyiXmz+R70TcUMbrg==",
+      "dev": true
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -12158,12 +12178,6 @@
         }
       }
     },
-    "faker": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
-      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg==",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -12318,9 +12332,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rizefinance/rize-js",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Rize API wrapper",
   "main": "index.js",
   "typings": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "lint": "eslint . --ext .js,.ts",
     "lint-fix": "eslint . --ext .js,.ts --fix",
     "docs:build": "tsc && documentation build lib/** -f md -o docs.md",
-    "test": "npm run lint && mocha $1",
+    "test": "npm run lint-fix && mocha $1",
     "local:publish": "npm run docs:build && npm unpublish --force --registry http://localhost:4873 @rizefinance/rize-js && npm publish --registry http://localhost:4873"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@faker-js/faker": "^6.0.0-alpha.6",
     "@types/jsrsasign": "^9.0.3",
     "@types/stompit": "^0.26.3",
     "@types/validator": "^13.7.1",
@@ -25,7 +26,6 @@
     "dotenv": "^16.0.0",
     "eslint": "^7.32.0",
     "eslint-plugin-chai-friendly": "^0.7.2",
-    "faker": "^6.6.6",
     "mocha": "^8.4.0",
     "mocha-logger": "^1.0.7",
     "ssn": "^1.0.3",

--- a/test/core/compliance-workflow.spec.js
+++ b/test/core/compliance-workflow.spec.js
@@ -13,7 +13,7 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 const mlog = require('mocha-logger');
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 const rizeClient = require('../helpers/rizeClient');
 

--- a/test/core/custodial-account.spec.js
+++ b/test/core/custodial-account.spec.js
@@ -8,7 +8,7 @@ const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 const rizeClient = require('../helpers/rizeClient');
 

--- a/test/core/customer.create.spec.js
+++ b/test/core/customer.create.spec.js
@@ -8,7 +8,7 @@ const expect = chai.expect;
 
 const mlog = require('mocha-logger');
 const uuid = require('uuid').v4;
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 const rizeClient = require('../helpers/rizeClient');
 

--- a/test/core/customer.spec.js
+++ b/test/core/customer.spec.js
@@ -10,7 +10,7 @@ const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 const { RandomSSN } = require('ssn');
 
 const rizeClient = require('../helpers/rizeClient');

--- a/test/core/debit-card.spec.js
+++ b/test/core/debit-card.spec.js
@@ -4,7 +4,7 @@ const utils = require('../../lib/test-utils');
 
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;

--- a/test/core/pool.spec.js
+++ b/test/core/pool.spec.js
@@ -8,7 +8,7 @@ const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 const rizeClient = require('../helpers/rizeClient');
 

--- a/test/core/synthetic-account.spec.js
+++ b/test/core/synthetic-account.spec.js
@@ -6,7 +6,7 @@ const utils = require('../../lib/test-utils');
 
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;

--- a/test/core/transfer.spec.js
+++ b/test/core/transfer.spec.js
@@ -6,7 +6,7 @@ const utils = require('../../lib/test-utils');
 
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;

--- a/types/lib/core/typedefs/customer.typedefs.d.ts
+++ b/types/lib/core/typedefs/customer.typedefs.d.ts
@@ -77,11 +77,11 @@ export type CustomerProfileAnswerDetails = {
      */
     profile_requirement_uid: string;
     /**
-     * - The Customer's response to the Profile Requirement
+     * - The Customer's response to the Profile Requirement, pending on the question may require a string or object ordered hash list response.
      *
      * /**
      */
-    profile_response: string;
+    profile_response: string | object;
 };
 export type CustomerListQuery = {
     /**


### PR DESCRIPTION
Depending on the question of the profile question, we need to allow a hash object

EX: 
```
const answers = [
      {
        profile_requirement_uid: 'uid_of_PR',
        profile_response: {
          '0': 'First Ordered Response',
          '1': 'Second Ordered Response',
          '2': 'Third Ordered Response'',
          '3': 'Forth Ordered Response'',
        },
      },
    ];
```