### PR TITLE
feat:[RF-1766] added unlock_all_params to unlock endpoint

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -868,11 +868,12 @@ the unlock can be performed by the Custodial Partner, the Client, or Rize.
 
 *   `uid` **[string][371]** Rize-generated unique customer id
 *   `unlockReason` **[string][371]** The reason that the Customer is being unlocked. (optional, default `null`)
+*   `unlock_all_secondary` **[boolean][375]** allows the requestor to specify whether all secondary customers should be unlocked (optional, default `null`)
 
 #### Examples
 
 ```javascript
-const customer = await rize.customer.unlock(customerUid, unlockReason);
+const customer = await rize.customer.unlock(customerUid, unlockReason, unlock_all_secondary);
 ```
 
 Returns **[Promise][370]<[Customer][265]>** A promise that returns the unlocked Customer if resolved.

--- a/lib/core/customer.js
+++ b/lib/core/customer.js
@@ -611,7 +611,7 @@ class CustomerService {
    * @param {string} unlockReason - The reason that the Customer is being unlocked.
    * @param {true|false} unlock_all_secondary - allows the requestor to specify whether all secondary customers should be unlocked
    * @returns {Promise<Customer>} A promise that returns the unlocked Customer if resolved.
-   * @example const customer = await rize.customer.unlock(customerUid, unlockReason);
+   * @example const customer = await rize.customer.unlock(customerUid, unlockReason, unlock_all_secondary);
    */
     async unlock(uid, unlockReason = null, unlock_all_secondary = null) {
         if (validator.isEmpty(uid, { ignore_whitespace: true })) {

--- a/lib/core/customer.js
+++ b/lib/core/customer.js
@@ -609,10 +609,11 @@ class CustomerService {
    * the unlock can be performed by the Custodial Partner, the Client, or Rize.
    * @param {string} uid - Rize-generated unique customer id
    * @param {string} unlockReason - The reason that the Customer is being unlocked.
+   * @param {'true' | 'false'} unlock_all_secondary - allows the requestor to specify whether all secondary customers should be unlocked
    * @returns {Promise<Customer>} A promise that returns the unlocked Customer if resolved.
    * @example const customer = await rize.customer.unlock(customerUid, unlockReason);
    */
-    async unlock(uid, unlockReason = null) {
+    async unlock(uid, unlockReason = null, unlock_all_secondary = null) {
         if (validator.isEmpty(uid, { ignore_whitespace: true })) {
             throw new Error('Customer "uid" is required.');
         }
@@ -620,8 +621,13 @@ class CustomerService {
             throw new Error('"unlockReason" must be a string.');
         }
 
+        if (unlock_all_secondary && !['true', 'false'].includes(unlock_all_secondary)) {
+            throw new Error('"unlock_all_secondary" can only be true, false or null.');
+        }
+
         const response = await this._api.put(`/customers/${uid}/unlock`, {
             unlock_reason: unlockReason,
+            unlock_all_secondary: unlock_all_secondary,
         });
 
         return response.data;

--- a/lib/core/customer.js
+++ b/lib/core/customer.js
@@ -609,7 +609,7 @@ class CustomerService {
    * the unlock can be performed by the Custodial Partner, the Client, or Rize.
    * @param {string} uid - Rize-generated unique customer id
    * @param {string} unlockReason - The reason that the Customer is being unlocked.
-   * @param {'true' | 'false'} unlock_all_secondary - allows the requestor to specify whether all secondary customers should be unlocked
+   * @param {true | false} unlock_all_secondary - allows the requestor to specify whether all secondary customers should be unlocked
    * @returns {Promise<Customer>} A promise that returns the unlocked Customer if resolved.
    * @example const customer = await rize.customer.unlock(customerUid, unlockReason);
    */
@@ -621,7 +621,7 @@ class CustomerService {
             throw new Error('"unlockReason" must be a string.');
         }
 
-        if (unlock_all_secondary && !['true', 'false'].includes(unlock_all_secondary)) {
+        if (unlock_all_secondary && ![true, false].includes(unlock_all_secondary)) {
             throw new Error('"unlock_all_secondary" can only be true, false or null.');
         }
 

--- a/lib/core/customer.js
+++ b/lib/core/customer.js
@@ -609,7 +609,7 @@ class CustomerService {
    * the unlock can be performed by the Custodial Partner, the Client, or Rize.
    * @param {string} uid - Rize-generated unique customer id
    * @param {string} unlockReason - The reason that the Customer is being unlocked.
-   * @param {true | false} unlock_all_secondary - allows the requestor to specify whether all secondary customers should be unlocked
+   * @param {true|false} unlock_all_secondary - allows the requestor to specify whether all secondary customers should be unlocked
    * @returns {Promise<Customer>} A promise that returns the unlocked Customer if resolved.
    * @example const customer = await rize.customer.unlock(customerUid, unlockReason);
    */
@@ -621,8 +621,10 @@ class CustomerService {
             throw new Error('"unlockReason" must be a string.');
         }
 
-        if (unlock_all_secondary && ![true, false].includes(unlock_all_secondary)) {
-            throw new Error('"unlock_all_secondary" can only be true, false or null.');
+        if (unlock_all_secondary !== null) {
+            if(!(unlock_all_secondary === true || unlock_all_secondary === false )){
+                throw new Error('"unlock_all_secondary" can only be true, false or null.');
+            }
         }
 
         const response = await this._api.put(`/customers/${uid}/unlock`, {

--- a/test/core/customer.spec.js
+++ b/test/core/customer.spec.js
@@ -598,6 +598,20 @@ describe('Customer', () => {
             );
         });
 
+        it('Throws an error if "unlock_all_secondary" is 0', () => {
+            const promise = rizeClient.customer.unlock(customerUid, unlockReason, 0);
+            return expect(promise).to.eventually.be.rejectedWith(
+                '"unlock_all_secondary" can only be true, false or null.'
+            );
+        });
+
+        it('Throws an error if "unlock_all_secondary" is 1', () => {
+            const promise = rizeClient.customer.unlock(customerUid, unlockReason, 1);
+            return expect(promise).to.eventually.be.rejectedWith(
+                '"unlock_all_secondary" can only be true, false or null.'
+            );
+        });
+
         it('Unlocks the customer account without unlock_reason', async () => {
             await rizeClient.customer.lock(customerUid, unlockReason);
             const unlockedCustomer = await rizeClient.customer.unlock(customerUid);

--- a/test/core/customer.spec.js
+++ b/test/core/customer.spec.js
@@ -591,6 +591,13 @@ describe('Customer', () => {
             );
         });
 
+        it('Throws an error if "unlock_all_secondary" is invalid', () => {
+            const promise = rizeClient.customer.unlock(customerUid, unlockReason, 'invalid');
+            return expect(promise).to.eventually.be.rejectedWith(
+                '"unlock_all_secondary" can only be true, false or null.'
+            );
+        });
+
         it('Unlocks the customer account without unlock_reason', async () => {
             await rizeClient.customer.lock(customerUid, unlockReason);
             const unlockedCustomer = await rizeClient.customer.unlock(customerUid);
@@ -603,6 +610,28 @@ describe('Customer', () => {
             const unlockedCustomer = await rizeClient.customer.unlock(
                 customerUid,
                 unlockReason
+            );
+            expect(unlockedCustomer.lock_reason).equals(null);
+            expect(unlockedCustomer.locked_at).equals(null);
+        });
+
+        it('Unlocks the customer account with unlock_all_customers as false', async () => {
+            await rizeClient.customer.lock(customerUid, unlockReason);
+            const unlockedCustomer = await rizeClient.customer.unlock(
+                customerUid,
+                unlockReason,
+                'false'
+            );
+            expect(unlockedCustomer.lock_reason).equals(null);
+            expect(unlockedCustomer.locked_at).equals(null);
+        });
+
+        it('Unlocks the customer account with unlock_all_customers as true', async () => {
+            await rizeClient.customer.lock(customerUid, unlockReason);
+            const unlockedCustomer = await rizeClient.customer.unlock(
+                customerUid,
+                unlockReason,
+                'true'
             );
             expect(unlockedCustomer.lock_reason).equals(null);
             expect(unlockedCustomer.locked_at).equals(null);

--- a/test/core/customer.spec.js
+++ b/test/core/customer.spec.js
@@ -620,7 +620,7 @@ describe('Customer', () => {
             const unlockedCustomer = await rizeClient.customer.unlock(
                 customerUid,
                 unlockReason,
-                'false'
+                false
             );
             expect(unlockedCustomer.lock_reason).equals(null);
             expect(unlockedCustomer.locked_at).equals(null);
@@ -631,7 +631,7 @@ describe('Customer', () => {
             const unlockedCustomer = await rizeClient.customer.unlock(
                 customerUid,
                 unlockReason,
-                'true'
+                true
             );
             expect(unlockedCustomer.lock_reason).equals(null);
             expect(unlockedCustomer.locked_at).equals(null);

--- a/types/lib/core/customer.d.ts
+++ b/types/lib/core/customer.d.ts
@@ -238,10 +238,11 @@ declare class CustomerService {
    * the unlock can be performed by the Custodial Partner, the Client, or Rize.
    * @param {string} uid - Rize-generated unique customer id
    * @param {string} unlockReason - The reason that the Customer is being unlocked.
+   * @param {true|false} unlock_all_secondary - allows the requestor to specify whether all secondary customers should be unlocked
    * @returns {Promise<Customer>} A promise that returns the unlocked Customer if resolved.
    * @example const customer = await rize.customer.unlock(customerUid, unlockReason);
    */
-    unlock(uid: string, unlockReason?: string): Promise<Customer>;
+    unlock(uid: string, unlockReason?: string, unlock_all_secondary?: boolean): Promise<Customer>;
 }
 declare namespace CustomerService {
     export { CustomerListQuery, CustomerDetails, CustomerDetailsParams, Customer, CustomerProfileAnswerDetails, RizeList };


### PR DESCRIPTION
## Ticket
- https://rizemoney.atlassian.net/browse/RF-1766

## Dependencies
- ...

## Changes
- Adds `unlock_all_secondary` to `PUT /customers/{uid}/unlock `
- Adds validation for only true and false

## Pre-Test Plan
- ...

## Test Plan
1. Pull down this branch.
2. Test scenario
