### PR TITLE
[R30-2180] Peer to Peer Transfer Support

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1861,8 +1861,9 @@ only Synthetic Accounts allowed in a Transfer request are:
 *   `externalUid` **[string][371]** A unique identifier Client supplies. It should be given when creating a new resource and must be unique within the resource type. If the same value is given, no new resource will be created.
 *   `sourceSyntheticAccountUid` **[string][371]** Synthetic Account to pull asset from. Must be an active liability or external-type account. Cannot be equal to `destination_synthetic_account_uid`.
 *   `destinationSyntheticAccountUid` **[string][371]** Synthetic Account where the asset should land. Must be an active liability or external-type account. Cannot be equal to `source_synthetic_account_uid`.
-*   `initiatingCustomerUid` **[string][371]**&#x20;
+*   `initiatingCustomerUid` **[string][371]** The uid of the owner of the source Synthetic Account.
 *   `usTransferAmount` **[string][371]** The USD amount to transfer.
+*   `destinationCustomerUid` **[string][371]** The uid of the owner of the destination Synthetic Account. If not provided, it is assumed to be the initiatingCustomerUid.
 
 #### Examples
 

--- a/docs.md
+++ b/docs.md
@@ -2504,13 +2504,14 @@ Type: [Object][373]
     *   ***settled*** - The Transaction is complete. All of the related Transaction Events are settled.
     *   ***failed*** - The Transaction has failed. This state indicates that one of the related Transaction Events could not be settled. A failed Transaction may require the reversal of a related Synthetic Line Item and/or Custodial Line Item.
 *   `us_dollar_amount` **[string][371]** The amount will never be negative
-*   `type` **(`"atm_withdrawal"` | `"card_purchase"` | `"card_refund"` | `"dispute"` | `"external_transfer"` | `"fee"` | `"internal_transfer"` | `"other"` | `"reversed_transfer"` | `"third_party_transfer"`)** ***atm\_withdrawal*** - Cash is withdrawn at an ATM using a Debit Card.*   ***card\_purchase*** - A purchase is made using a Debit Card.
+*   `type` **(`"atm_withdrawal"` | `"card_purchase"` | `"card_refund"` | `"dispute"` | `"external_transfer"` | `"fee"` | `"internal_transfer"` | `"other"` | `"peer_to_peer_transfer"` | `"reversed_transfer"` | `"third_party_transfer"`)** ***atm\_withdrawal*** - Cash is withdrawn at an ATM using a Debit Card.*   ***card\_purchase*** - A purchase is made using a Debit Card.
     *   ***card\_refund*** - A previous Debit Card Transaction is refunded.
     *   ***dispute*** - If a Customer claims that a Transaction was created in error, one or more Transactions will be created with this type to credit or debit based on the dispute outcome.
     *   ***external\_transfer*** - This Transaction originates from a Transfer to or from an external Synthetic Account.
     *   ***fee*** - A fee charged to the account. This includes ACH reversals and Debit Card ATM fees.
     *   ***internal\_transfer*** - The Transaction originates from a Transfer between two Synthetic Accounts that are not of type external.
     *   ***other*** - Miscellaneous Transactions, such as write-offs.
+    *   ***peer_to_peer_transfer*** - The Transaction originates from a Transfer between two non-external Synthetic Accounts each owned by a different Customer.
     *   ***reversed\_transfer*** - A previous Transfer is reversed; when a Transfer is reversed, the type of the original Transaction will be `external_transfer`, `internal_transfer`, or `third_party_transfer`.
     *   ***third\_party\_transfer*** - The Transaction was initiated from an external source. This will likely be an RDFI ACH, where an external source initiates a withdrawal from or deposit to the account.
 *   `net_asset` **(`"positive"` | `"negative"` | `"neutral"`)** Indicates whether the Customer's asset has gone up (`positive`), gone down (`negative`) or stayed the same (`neutral`) as a result of this Transaction.

--- a/docs.md
+++ b/docs.md
@@ -2651,7 +2651,8 @@ Type: [Object][373]
 *   `external_uid` **[string][371]** A unique identifier Client supplies. It should be given when creating a new resource and must be unique within the resource type. If the same value is given, no new resource will be created.
 *   `source_synthetic_account_uid` **[string][371]** Synthetic Account to pull asset from. Must be an active liability or external-type account. Cannot be equal to `destination_synthetic_account_uid`.
 *   `destination_synthetic_account_uid` **[string][371]** Synthetic Account where the asset should land. Must be an active liability or external-type account. Cannot be equal to `source_synthetic_account_uid`.
-*   `initiating_customer_uid` **[string][371]**&#x20;
+*   `initiating_customer_uid` **[string][371]** The customer connected to the source Synthetic Account.
+*   `destination_customer_uid` **[string][371]** The customer connected to the destination Synthetic Account.
 *   `usd_transfer_amount` **[string][371]** The USD amount to transfer
 *   `status` **(`"queued"` | `"pending"` | `"settled"` | `"failed"`)** A value indicating the overall status of the Transfer:*   ***queued*** - Transfers begin in the Queued status. Queued indicates that Rize has received a valid Transfer request and is preparing the Transfer.
     *   ***pending*** - Transfers move from a status of Queued to a status of Pending. A Pending status indicates that Rize has begun the movement of funds to complete the Transfer.

--- a/lib/core/transaction.js
+++ b/lib/core/transaction.js
@@ -7,13 +7,13 @@ const utils = require('../utils');
 class TransactionService {
     /**
      * @hideconstructor
-     * @param {import('axios').AxiosInstance} api 
+     * @param {import('axios').AxiosInstance} api
      */
     constructor(api) {
         /** @ignore @protected */ this._api = api;
     }
 
-    /** 
+    /**
      * @ignore @protected
      * Validates query parameter object for getList method.
      * @param {} query - An object containing key value pair for filtering the results list.
@@ -28,6 +28,7 @@ class TransactionService {
             'fee',
             'internal_transfer',
             'other',
+            'peer_to_peer_transfer',
             'reversed_transfer',
             'third_party_transfer'
         ];
@@ -101,7 +102,7 @@ class TransactionService {
     /**
      * @ignore @protected
      * Validates the parameters for the "get" method
-     * @param {string} uid 
+     * @param {string} uid
      */
     _validateGetParams(uid) {
         if (validator.isEmpty(uid, { ignore_whitespace: true })) {
@@ -109,7 +110,7 @@ class TransactionService {
         }
     }
 
-    /** 
+    /**
      * @ignore @protected
      * Validates query parameter object for getTransactionEventList method.
      * @param {} query - An object containing key value pair for filtering the results list.
@@ -174,7 +175,7 @@ class TransactionService {
     /**
      * @ignore @protected
      * Validates the parameters for the "getTransactionEvent" method
-     * @param {string} uid 
+     * @param {string} uid
      */
     _validateGetTransactionEventParams(uid) {
         if (validator.isEmpty(uid, { ignore_whitespace: true })) {
@@ -182,7 +183,7 @@ class TransactionService {
         }
     }
 
-    /** 
+    /**
      * @ignore @protected
      * Validates query parameter object for getSyntheticLineItemList method.
      * @param {} query - An object containing key value pair for filtering the results list.
@@ -245,7 +246,7 @@ class TransactionService {
     /**
      * @ignore @protected
      * Validates the parameters for the "getSyntheticLineItem" method
-     * @param {string} uid 
+     * @param {string} uid
      */
     _validateGetSyntheticLineItemParams(uid) {
         if (validator.isEmpty(uid, { ignore_whitespace: true })) {
@@ -253,7 +254,7 @@ class TransactionService {
         }
     }
 
-    /** 
+    /**
      * @ignore @protected
      * Validates query parameter object for getCustodialLineItemList method.
      * @param {} query - An object containing key value pair for filtering the results list.
@@ -314,7 +315,7 @@ class TransactionService {
     /**
      * @ignore @protected
      * Validates the parameters for the "getCustodialLineItem" method
-     * @param {string} uid 
+     * @param {string} uid
      */
     _validateGetCustodialLineItemParams(uid) {
         if (validator.isEmpty(uid, { ignore_whitespace: true })) {
@@ -323,7 +324,7 @@ class TransactionService {
     }
 
     /**
-     * Retrieves a list of Transactions filtered by the given parameters. 
+     * Retrieves a list of Transactions filtered by the given parameters.
      * @param {TransactionListQuery} [query] - An object containing key value pair for filtering the results list.
      * @returns {Promise<RizeList<Transaction>>} A promise that returns a Transaction List if resolved.
      * @example
@@ -364,7 +365,7 @@ class TransactionService {
 
     /**
      * Get a single Transaction
-     * 
+     *
      * @param {string} uid - Rize-generated unique transaction id
      * @returns {Promise<Transaction>} A promise that returns a Transaction if resolved.
      * @example const transaction = await rize.transaction.get(transactionUid);
@@ -378,7 +379,7 @@ class TransactionService {
     }
 
     /**
-     * Retrieves a list of TransactionEvents filtered by the given parameters. 
+     * Retrieves a list of TransactionEvents filtered by the given parameters.
      * @param {TransactionEventListQuery} [query] - An object containing key value pair for filtering the results list.
      * @returns {Promise<RizeList<TransactionEvent>>} A promise that returns a TransactionEvent List if resolved.
      * @example
@@ -415,7 +416,7 @@ class TransactionService {
 
     /**
      * Get a single Transaction Event
-     * 
+     *
      * @param {string} uid - Rize-generated unique transaction event id
      * @returns {Promise<TransactionEvent>} - A promise that returns a Transaction Event if resolved.
      * @example const transactionEvent = await rize.transaction.getTransactionEvent(transactionEventUid);
@@ -429,7 +430,7 @@ class TransactionService {
     }
 
     /**
-     * Retrieves a list of Synthetic Line Items filtered by the given parameters. 
+     * Retrieves a list of Synthetic Line Items filtered by the given parameters.
      * @param {SyntheticLineItemListQuery} query - An object containing key value pair for filtering the results list.
      * @returns {Promise<RizeList<SyntheticLineItem>>} A promise that returns a Synthetic Line Item List if resolved.
      * @example
@@ -466,7 +467,7 @@ class TransactionService {
 
     /**
      * Get a single Synthetic Line Item
-     * 
+     *
      * @param {string} uid - Rize-generated unique Synthetic Line Item id
      * @returns {Promise<SyntheticLineItem>} A promise that returns a Synthetic Line Item if resolved.
      * @example const syntheticLineItem = await rize.transaction.getSyntheticLineItem(syntheticLineItemUid);
@@ -480,7 +481,7 @@ class TransactionService {
     }
 
     /**
-     * 
+     *
      * @param {CustodialLineItemListQuery} query - An object containing key value pair for filtering the results list.
      * @returns {Promise<RizeList<CustodialLineItem>>} A promise that returns a Custodial Line Item List if resolved.
      * @example
@@ -521,7 +522,7 @@ class TransactionService {
 
     /**
      * Get a single Custodial Line Item
-     * 
+     *
      * @param {string} uid - Rize-generated unique Custodial Line Item id
      * @returns {Promise<CustodialLineItem>} A promise that returns a Custodial Line Item if resolved.
      * @example const custodialLineItem = await rize.transaction.getCustodialLineItem(custodialLineItemUid);

--- a/lib/core/transfer.js
+++ b/lib/core/transfer.js
@@ -7,13 +7,13 @@ const validator = require('validator');
 class TransferService {
     /**
      * @hideconstructor
-     * @param {import('axios').AxiosInstance} api 
+     * @param {import('axios').AxiosInstance} api
      */
     constructor(api) {
         /** @ignore @protected */ this._api = api;
     }
 
-    /** 
+    /**
      * @ignore @protected
      * Validates query parameter object for getList method.
      * @param {} query - An object containing key value pair for filtering the results list.
@@ -43,7 +43,7 @@ class TransferService {
     /**
      * @ignore @protected
      * Validates the parameters for the "get" method
-     * @param {string} uid 
+     * @param {string} uid
      */
     _validateGetParams(uid) {
         if (validator.isEmpty(uid, { ignore_whitespace: true })) {
@@ -54,11 +54,11 @@ class TransferService {
     /**
      * @ignore @protected
      * Validates the parameters for the "init" method
-     * @param {*} externalUid 
-     * @param {*} sourceSyntheticAccountUid 
-     * @param {*} destinationSyntheticAccountUid 
-     * @param {*} initiatingCustomerUid 
-     * @param {*} usTransferAmount 
+     * @param {*} externalUid
+     * @param {*} sourceSyntheticAccountUid
+     * @param {*} destinationSyntheticAccountUid
+     * @param {*} initiatingCustomerUid
+     * @param {*} usTransferAmount
      */
     _validateInitParams(
         externalUid,
@@ -89,7 +89,7 @@ class TransferService {
     }
 
     /**
-     * Retrieves a list of Tranfers filtered by the given parameters. 
+     * Retrieves a list of Tranfers filtered by the given parameters.
      * @param {TransferListQuery} query - An object containing key value pair for filtering the results list.
      * @returns {Promise<RizeList<Transfer>>} A promise that returns a Transfer List if resolved.
      * @example
@@ -122,7 +122,7 @@ class TransferService {
 
     /**
      * Get a single Transfer
-     * 
+     *
      * @param {string} uid - Rize-generated unique Transfer id
      * @returns {Promise<Transfer>} A promise that returns a Transfer if resolved.
      * @example const transfer = await rize.transfer.get(transferUid);
@@ -136,22 +136,23 @@ class TransferService {
     }
 
     /**
-     * Attempt to initiate a Transfer between two Synthetic Accounts. Before the Transfer will be initiated, 
-     * several checks will be performed to ensure there is sufficient balance in the source account and that 
-     * the initiating Customer has all the necessary access to both Synthetic Accounts. Depending on the 
-     * Synthetic Account Types involved and the Program configuration, a new Transfer could complete instantly 
+     * Attempt to initiate a Transfer between two Synthetic Accounts. Before the Transfer will be initiated,
+     * several checks will be performed to ensure there is sufficient balance in the source account and that
+     * the initiating Customer has all the necessary access to both Synthetic Accounts. Depending on the
+     * Synthetic Account Types involved and the Program configuration, a new Transfer could complete instantly
      * or take as many as 6 business days.
-     * 
-     * Note: Rize is working to support any Synthetic Account as the source and destination. Currently, the 
+     *
+     * Note: Rize is working to support any Synthetic Account as the source and destination. Currently, the
      * only Synthetic Accounts allowed in a Transfer request are:
-     * 
+     *
      * - two general liability Synthetic Accounts
      * - Master Synthetic Accounts and external Synthetic Accounts
      * @param {string} externalUid - A unique identifier Client supplies. It should be given when creating a new resource and must be unique within the resource type. If the same value is given, no new resource will be created.
      * @param {string} sourceSyntheticAccountUid - Synthetic Account to pull asset from. Must be an active liability or external-type account. Cannot be equal to `destination_synthetic_account_uid`.
      * @param {string} destinationSyntheticAccountUid - Synthetic Account where the asset should land. Must be an active liability or external-type account. Cannot be equal to `source_synthetic_account_uid`.
-     * @param {string} initiatingCustomerUid 
+     * @param {string} initiatingCustomerUid -The uid of the owner of the source Synthetic Account.
      * @param {string} usTransferAmount - The USD amount to transfer.
+     * @param {string} destinationCustomerUid - The uid of the owner of the destination Synthetic Account. If not provided, it is assumed to be the initiatingCustomerUid.
      * @returns {Promise<Transfer>} A promise that returns a Transfer if resolved.
      * @example
      * const transfer = await rize.transfer.init(
@@ -167,7 +168,8 @@ class TransferService {
         sourceSyntheticAccountUid,
         destinationSyntheticAccountUid,
         initiatingCustomerUid,
-        usTransferAmount
+        usTransferAmount,
+        destinationCustomerUid = null
     ) {
         this._validateInitParams(
             externalUid,
@@ -184,7 +186,8 @@ class TransferService {
                 'source_synthetic_account_uid': sourceSyntheticAccountUid,
                 'destination_synthetic_account_uid': destinationSyntheticAccountUid,
                 'initiating_customer_uid': initiatingCustomerUid,
-                'usd_transfer_amount': usTransferAmount
+                'usd_transfer_amount': usTransferAmount,
+                'destination_customer_uid': destinationCustomerUid
             }
         );
 

--- a/lib/core/typedefs/transaction.typedefs.js
+++ b/lib/core/typedefs/transaction.typedefs.js
@@ -6,25 +6,25 @@
  * @property {number|null} [transfer_uid] - The UID of the Transfer this Transaction is associated with, if any.
  * @property {string} source_synthetic_account_uid - Synthetic Account from where the asset is pulled
  * @property {string} destination_synthetic_account_uid - Synthetic Account where the asset is landed
- * @property {Array<string>} transaction_event_uids - A list of UIDS referring to Transaction Events belonging to this Transaction, if any. 
- * An empty array will be returned if there is no event involved. 
- * The array may contain more values as the Transaction progresses and will no longer grow when its status becomes settled. 
+ * @property {Array<string>} transaction_event_uids - A list of UIDS referring to Transaction Events belonging to this Transaction, if any.
+ * An empty array will be returned if there is no event involved.
+ * The array may contain more values as the Transaction progresses and will no longer grow when its status becomes settled.
  * The array may still be empty by the time the Transaction is `settled` if there is no custodial asset movement as a result of this Transaction.
- * @property {Array<string>} custodial_account_uids - A list of UIDS referring to Custodial Accounts that are so far invovled in this Transaction. 
- * An empty array will be returned if there is Custodial Account involved. 
- * The array may contain more values as the Transaction progresses and will no longer grow when its status becomes settled. 
+ * @property {Array<string>} custodial_account_uids - A list of UIDS referring to Custodial Accounts that are so far invovled in this Transaction.
+ * An empty array will be returned if there is Custodial Account involved.
+ * The array may contain more values as the Transaction progresses and will no longer grow when its status becomes settled.
  * The array may still be empty by the time the Transaction is `settled` if there is no custodial asset movement as a result of this Transaction.
- * @property {'queued'|'pending'|'settled'|'failed'} status - When a Transfer is created via `transfers.init()`, an associated Transaction is created with queued status. 
+ * @property {'queued'|'pending'|'settled'|'failed'} status - When a Transfer is created via `transfers.init()`, an associated Transaction is created with queued status.
  * If it involves at least one custodial transfer, once the custodial transfer is initiated, the status will transition to pending.
- * 
+ *
  * Once a Transaction is settled, whether it has asset movement in custodial level, or is synthetic-only, or is RDFI (no Transfer associated), it will have a settled status.
- * 
+ *
  * - ***queued*** - The Transaction is being prepared as a result of a Transfer request. Transactions that originate outside of Rize (e.g., debit card transactions, RDFI ACHs, direct deposits, etc.) will not be given this status.
  * - ***pending*** - The Transaction is being processed. This state will persist until all related Transaction Events have settled or could not be completed.
  * - ***settled*** - The Transaction is complete. All of the related Transaction Events are settled.
  * - ***failed*** - The Transaction has failed. This state indicates that one of the related Transaction Events could not be settled. A failed Transaction may require the reversal of a related Synthetic Line Item and/or Custodial Line Item.
  * @property {string} us_dollar_amount - The amount will never be negative
- * @property {'atm_withdrawal'|'card_purchase'|'card_refund'|'dispute'|'external_transfer'|'fee'|'internal_transfer'|'other'|'reversed_transfer'|'third_party_transfer'} type
+ * @property {'atm_withdrawal'|'card_purchase'|'card_refund'|'dispute'|'external_transfer'|'fee'|'internal_transfer'|'other'|'peer_to_peer_transfer'|'reversed_transfer'|'third_party_transfer'} type
  * - ***atm_withdrawal*** - Cash is withdrawn at an ATM using a Debit Card.
  * - ***card_purchase*** - A purchase is made using a Debit Card.
  * - ***card_refund*** - A previous Debit Card Transaction is refunded.
@@ -33,6 +33,7 @@
  * - ***fee*** - A fee charged to the account. This includes ACH reversals and Debit Card ATM fees.
  * - ***internal_transfer*** - The Transaction originates from a Transfer between two Synthetic Accounts that are not of type external.
  * - ***other*** - Miscellaneous Transactions, such as write-offs.
+ * - ***peer_to_peer_transfer*** - The Transaction originates from a Transfer between two non-external Synthetic Accounts each owned by a different Customer.
  * - ***reversed_transfer*** - A previous Transfer is reversed; when a Transfer is reversed, the type of the original Transaction will be `external_transfer`, `internal_transfer`, or `third_party_transfer`.
  * - ***third_party_transfer*** - The Transaction was initiated from an external source. This will likely be an RDFI ACH, where an external source initiates a withdrawal from or deposit to the account.
  * @property {'positive'|'negative'|'neutral'} net_asset - Indicates whether the Customer's asset has gone up (`positive`), gone down (`negative`) or stayed the same (`neutral`) as a result of this Transaction.

--- a/lib/core/typedefs/transfer.typedefs.js
+++ b/lib/core/typedefs/transfer.typedefs.js
@@ -4,7 +4,8 @@
  * @property {string} external_uid - A unique identifier Client supplies. It should be given when creating a new resource and must be unique within the resource type. If the same value is given, no new resource will be created.
  * @property {string} source_synthetic_account_uid - Synthetic Account to pull asset from. Must be an active liability or external-type account. Cannot be equal to `destination_synthetic_account_uid`.
  * @property {string} destination_synthetic_account_uid - Synthetic Account where the asset should land. Must be an active liability or external-type account. Cannot be equal to `source_synthetic_account_uid`.
- * @property {string} initiating_customer_uid
+ * @property {string} initiating_customer_uid - The customer connected to the source Synthetic Account.
+ * @property {string} destination_customer_uid - The customer connected to the destination Synthetic Account.
  * @property {string} usd_transfer_amount - The USD amount to transfer
  * @property {'queued'|'pending'|'settled'|'failed'} status
  * A value indicating the overall status of the Transfer:

--- a/test/core/transaction.spec.js
+++ b/test/core/transaction.spec.js
@@ -60,7 +60,7 @@ describe('Transaction', () => {
             const query = { type: '' };
             const promise = rizeClient.transaction.getList(query);
             return expect(promise).to.eventually.be.rejectedWith(
-                '"type" query must be an array. Accepted values inside the array are: atm_withdrawal | card_purchase | card_refund | dispute | external_transfer | fee | internal_transfer | other | reversed_transfer | third_party_transfer'
+                '"type" query must be an array. Accepted values inside the array are: atm_withdrawal | card_purchase | card_refund | dispute | external_transfer | fee | internal_transfer | other | peer_to_peer_transfer | reversed_transfer | third_party_transfer'
             );
         });
 
@@ -68,7 +68,7 @@ describe('Transaction', () => {
             const query = { type: [''] };
             const promise = rizeClient.transaction.getList(query);
             return expect(promise).to.eventually.be.rejectedWith(
-                'Accepted values in the "type" query are: atm_withdrawal | card_purchase | card_refund | dispute | external_transfer | fee | internal_transfer | other | reversed_transfer | third_party_transfer'
+                'Accepted values in the "type" query are: atm_withdrawal | card_purchase | card_refund | dispute | external_transfer | fee | internal_transfer | other | peer_to_peer_transfer | reversed_transfer | third_party_transfer'
             );
         });
 

--- a/types/lib/core/transfer.d.ts
+++ b/types/lib/core/transfer.d.ts
@@ -71,6 +71,7 @@ declare class TransferService {
      * @param {string} destinationSyntheticAccountUid - Synthetic Account where the asset should land. Must be an active liability or external-type account. Cannot be equal to `source_synthetic_account_uid`.
      * @param {string} initiatingCustomerUid
      * @param {string} usTransferAmount - The USD amount to transfer.
+     * @param {string} destinationCustomerUid - The uid of the owner of the destination Synthetic Account. If not provided, it is assumed to be the initiatingCustomerUid.
      * @returns {Promise<Transfer>} A promise that returns a Transfer if resolved.
      * @example
      * const transfer = await rize.transfer.init(
@@ -81,7 +82,7 @@ declare class TransferService {
      *     100
      * );
      */
-    init(externalUid: string, sourceSyntheticAccountUid: string, destinationSyntheticAccountUid: string, initiatingCustomerUid: string, usTransferAmount: string): Promise<Transfer>;
+    init(externalUid: string, sourceSyntheticAccountUid: string, destinationSyntheticAccountUid: string, initiatingCustomerUid: string, usTransferAmount: string, destinationCustomerUid?: string): Promise<Transfer>;
 }
 declare namespace TransferService {
     export { TransferListQuery, Transfer, RizeList };

--- a/types/lib/core/typedefs/transaction.typedefs.d.ts
+++ b/types/lib/core/typedefs/transaction.typedefs.d.ts
@@ -62,10 +62,11 @@ export type Transaction = {
      * - ***fee*** - A fee charged to the account. This includes ACH reversals and Debit Card ATM fees.
      * - ***internal_transfer*** - The Transaction originates from a Transfer between two Synthetic Accounts that are not of type external.
      * - ***other*** - Miscellaneous Transactions, such as write-offs.
+     * - ***peer_to_peer_transfer*** - The Transaction originates from a Transfer between two non-external Synthetic Accounts each owned by a different Customer.
      * - ***reversed_transfer*** - A previous Transfer is reversed; when a Transfer is reversed, the type of the original Transaction will be `external_transfer`, `internal_transfer`, or `third_party_transfer`.
      * - ***third_party_transfer*** - The Transaction was initiated from an external source. This will likely be an RDFI ACH, where an external source initiates a withdrawal from or deposit to the account.
      */
-    type: 'atm_withdrawal' | 'card_purchase' | 'card_refund' | 'dispute' | 'external_transfer' | 'fee' | 'internal_transfer' | 'other' | 'reversed_transfer' | 'third_party_transfer';
+    type: 'atm_withdrawal' | 'card_purchase' | 'card_refund' | 'dispute' | 'external_transfer' | 'fee' | 'internal_transfer' | 'other' | 'peer_to_peer_transfer' | 'reversed_transfer' | 'third_party_transfer';
     /**
      * - Indicates whether the Customer's asset has gone up (`positive`), gone down (`negative`) or stayed the same (`neutral`) as a result of this Transaction.
      */

--- a/types/lib/core/typedefs/transfer.typedefs.d.ts
+++ b/types/lib/core/typedefs/transfer.typedefs.d.ts
@@ -15,7 +15,14 @@ export type Transfer = {
      * - Synthetic Account where the asset should land. Must be an active liability or external-type account. Cannot be equal to `source_synthetic_account_uid`.
      */
     destination_synthetic_account_uid: string;
+    /**
+     * The customer connected to the source Synthetic Account.
+     */
     initiating_customer_uid: string;
+    /**
+     * The customer connected to the destination Synthetic Account.
+     */
+    destination_customer_uid: string;
     /**
      * - The USD amount to transfer
      */


### PR DESCRIPTION
## Ticket
- https://rizemoney.atlassian.net/browse/R30-2180

## Changes
- Allow `peer_to_peer_transfer` in transaction search by type
- `destinationCustomerUid` can be passed in TransferService.init to create peer to peer transfer
- Document `destination_customer_uid` in the Transfer object returned in the transfer get requests
- Other formatting changes that happened due to format on save in my editor

## Test Plan

I did not add a test for peer to peer transfer because I don't know if it's fully implemented yet.
