### PR TITLE
[R30-2208] Send DELETE request with body correctly

### DIFF
--- a/lib/core/customer.js
+++ b/lib/core/customer.js
@@ -499,8 +499,11 @@ class CustomerService {
         const response = await this._api.delete(
             `/customers/${uid}`,
             {
-                archive_note: archiveNote,
-                can_apply_again: canApplyAgain
+                data: {
+                    archive_note: archiveNote,
+                    can_apply_again: canApplyAgain
+                
+                }
             }
         );
 

--- a/lib/core/customer.js
+++ b/lib/core/customer.js
@@ -502,7 +502,6 @@ class CustomerService {
                 data: {
                     archive_note: archiveNote,
                     can_apply_again: canApplyAgain
-                
                 }
             }
         );


### PR DESCRIPTION
## Ticket
- https://rizemoney.atlassian.net/browse/R30-2208

## Changes

https://masteringjs.io/tutorials/axios/delete-with-body

If you want to send a body along in a DELETE request, you have to pass it in the `data` field.

That means, my recent `canApplyAgain` addition didn't work, but it also means that the `archiveNote` _never_ worked.
